### PR TITLE
Rudimentary NextBot Support

### DIFF
--- a/lua/entities/npc_vj_human_base/init.lua
+++ b/lua/entities/npc_vj_human_base/init.lua
@@ -2022,7 +2022,7 @@ function ENT:Think()
 		//if self.CanOpenDoors && IsValid(blockingEnt) && (blockingEnt:GetClass() == "func_door" or blockingEnt:GetClass() == "func_door_rotating") && (blockingEnt:HasSpawnFlags(256) or blockingEnt:HasSpawnFlags(1024)) && !blockingEnt:HasSpawnFlags(512) then
 			//blockingEnt:Fire("Open")
 		//end
-		if (curSched.StopScheduleIfNotMoving == true or curSched.StopScheduleIfNotMoving_Any == true) && (!self:IsMoving() or (IsValid(blockingEnt) && (blockingEnt:IsNPC() or curSched.StopScheduleIfNotMoving_Any == true))) then // (self:GetGroundSpeedVelocity():Length() <= 0) == true
+		if (curSched.StopScheduleIfNotMoving == true or curSched.StopScheduleIfNotMoving_Any == true) && (!self:IsMoving() or (IsValid(blockingEnt) && ((blockingEnt:IsNPC() or blockingEnt:IsNextBot()) or curSched.StopScheduleIfNotMoving_Any == true))) then // (self:GetGroundSpeedVelocity():Length() <= 0) == true
 			self:ScheduleFinished(curSched)
 			//self:SetCondition(35)
 			//self:StopMoving()
@@ -2454,10 +2454,10 @@ function ENT:MeleeAttackCode()
 	if FindEnts != nil then
 		for _,v in pairs(FindEnts) do
 			if (self.VJ_IsBeingControlled == true && self.VJ_TheControllerBullseye == v) or (v:IsPlayer() && v.IsControlingNPC == true) then continue end
-			if (v:IsNPC() or (v:IsPlayer() && v:Alive() && GetConVar("ai_ignoreplayers"):GetInt() == 0)) && (self:Disposition(v) != D_LI) && (v != self) && (v:GetClass() != self:GetClass()) or (v:GetClass() == "prop_physics") or v:GetClass() == "func_breakable_surf" or v:GetClass() == "func_breakable" && (self:GetSightDirection():Dot((v:GetPos() -self:GetPos()):GetNormalized()) > math.cos(math.rad(self.MeleeAttackDamageAngleRadius))) then
+			if ((v:IsNPC() or v:IsNextBot()) or (v:IsPlayer() && v:Alive() && GetConVar("ai_ignoreplayers"):GetInt() == 0)) && (self:Disposition(v) != D_LI) && (v != self) && (v:GetClass() != self:GetClass()) or (v:GetClass() == "prop_physics") or v:GetClass() == "func_breakable_surf" or v:GetClass() == "func_breakable" && (self:GetSightDirection():Dot((v:GetPos() -self:GetPos()):GetNormalized()) > math.cos(math.rad(self.MeleeAttackDamageAngleRadius))) then
 				local doactualdmg = DamageInfo()
 				doactualdmg:SetDamage(self:VJ_GetDifficultyValue(self.MeleeAttackDamage))
-				if v:IsNPC() or v:IsPlayer() then doactualdmg:SetDamageForce(self:GetForward()*((doactualdmg:GetDamage()+100)*70)) end
+				if (v:IsNPC() or v:IsNextBot()) or v:IsPlayer() then doactualdmg:SetDamageForce(self:GetForward()*((doactualdmg:GetDamage()+100)*70)) end
 				doactualdmg:SetInflictor(self)
 				doactualdmg:SetAttacker(self)
 				v:TakeDamageInfo(doactualdmg, self)
@@ -2909,12 +2909,12 @@ function ENT:SelectSchedule()
 							//print("Is covered? ", cover_npc)
 							//print("Is gun covered? ", cover_wep)
 							local cover_npc_isObj = true -- The covered entity is NOT an NPC / Player
-							if cover_npc == false or (IsValid(cover_npc_ent) and (cover_npc_ent:IsNPC() or cover_npc_ent:IsPlayer())) then
+							if cover_npc == false or (IsValid(cover_npc_ent) and ((cover_npc_ent:IsNPC() or cover_npc_ent:IsNextBot()) or cover_npc_ent:IsPlayer())) then
 								cover_npc_isObj = false
 							end
 							if !wep.IsMeleeWeapon then
 								-- If friendly in line of fire, then move!
-								if !cover_npc_isObj && self.DoingWeaponAttack_Standing == true && CurTime() > self.TakingCoverT && IsValid(cover_wep_ent) && cover_wep_ent:IsNPC() && cover_wep_ent != self && (self:Disposition(cover_wep_ent) == D_LI or self:Disposition(cover_wep_ent) == D_NU) && cover_wep_tr.HitPos:Distance(cover_wep_tr.StartPos) <= 3000 then
+								if !cover_npc_isObj && self.DoingWeaponAttack_Standing == true && CurTime() > self.TakingCoverT && IsValid(cover_wep_ent) && (cover_wep_ent:IsNPC() or cover_wep_ent:IsNextBot()) && cover_wep_ent != self && (self:Disposition(cover_wep_ent) == D_LI or self:Disposition(cover_wep_ent) == D_NU) && cover_wep_tr.HitPos:Distance(cover_wep_tr.StartPos) <= 3000 then
 									local moveCheck = VJ_PICK(self:VJ_CheckAllFourSides(50, true, "0011"))
 									if moveCheck then
 										self:StopMoving()
@@ -2931,7 +2931,7 @@ function ENT:SelectSchedule()
 									-- Behind cover and I am taking cover, don't fire!
 									if CurTime() < self.TakingCoverT then
 										noAttack = true
-									elseif CurTime() > self.NextMoveOnGunCoveredT && ((cover_npc_tr.HitPos:Distance(myPos) > 150 && cover_npc_isObj == true) or (cover_wep == true && !cover_wep_ent:IsNPC() && !cover_wep_ent:IsPlayer())) then
+									elseif CurTime() > self.NextMoveOnGunCoveredT && ((cover_npc_tr.HitPos:Distance(myPos) > 150 && cover_npc_isObj == true) or (cover_wep == true && !(cover_wep_ent:IsNPC() or cover_wep_ent:IsNextBot()) && !cover_wep_ent:IsPlayer())) then
 										local nearestPos;
 										local enePos;
 										if IsValid(cover_npc_ent) then

--- a/lua/entities/npc_vj_tank_base/init.lua
+++ b/lua/entities/npc_vj_tank_base/init.lua
@@ -175,7 +175,7 @@ end
 ---------------------------------------------------------------------------------------------------------------------------------------------
 function ENT:Tank_RunOver(ent)
 	if (!IsValid(ent)) or (GetConVar("vj_npc_nomelee"):GetInt() == 1 /*or self.HasMeleeAttack == false*/) or (self.VJ_IsBeingControlled == true && self.VJ_TheControllerBullseye == ent) then return end
-	if self:Disposition(ent) == 1 && ent:Health() > 0 && self.Tank_IsMoving == true && (ent:IsNPC() && ent.VJ_IsHugeMonster != true && !runoverException[ent:GetClass()]) or (ent:IsPlayer() && self.PlayerFriendly == false && GetConVar("ai_ignoreplayers"):GetInt() == 0) then
+	if self:Disposition(ent) == 1 && ent:Health() > 0 && self.Tank_IsMoving == true && ((ent:IsNPC() or ent:IsNextBot()) && ent.VJ_IsHugeMonster != true && !runoverException[ent:GetClass()]) or (ent:IsPlayer() && self.PlayerFriendly == false && GetConVar("ai_ignoreplayers"):GetInt() == 0) then
 		self:Tank_CustomOnRunOver(ent)
 		self:Tank_Sound_RunOver()
 		ent:TakeDamage(self:VJ_GetDifficultyValue(8), self, self)

--- a/lua/entities/obj_vj_bullseye.lua
+++ b/lua/entities/obj_vj_bullseye.lua
@@ -77,7 +77,7 @@ end
 function ENT:Think()
 	if self.EnemyToIndividual == true then
 		self:AddFlags(FL_NOTARGET)
-		if IsValid(self.EnemyToIndividualEnt) && self.EnemyToIndividualEnt:IsNPC() then
+		if IsValid(self.EnemyToIndividualEnt) && (self.EnemyToIndividualEnt:IsNPC() or self.EnemyToIndividualEnt:IsNextBot()) then
 			self.EnemyToIndividualEnt:AddEntityRelationship(self,D_HT,99)
 			self:AddEntityRelationship(self.EnemyToIndividualEnt,D_HT,99)
 			if self.EnemyToIndividualEnt.IsVJBaseSNPC then

--- a/lua/entities/obj_vj_combineball.lua
+++ b/lua/entities/obj_vj_combineball.lua
@@ -105,7 +105,7 @@ function ENT:OnBounce(data, phys)
 	local closestDist = 1024
 	local target = NULL
 	for _, v in pairs(ents.FindInSphere(myPos, 1024)) do
-		if (!v:IsNPC() && !v:IsPlayer()) then continue end
+		if (!(v:IsNPC() or v:IsNextBot()) && !v:IsPlayer()) then continue end
 		if !owner:DoRelationshipCheck(v) then continue end
 		local dist = v:GetPos():Distance(myPos)
 		if dist < closestDist && dist > 20 then
@@ -150,7 +150,7 @@ function ENT:CustomOnPhysicsCollide(data, phys)
 		VJ_DestroyCombineTurret(self, hitEnt)
 	end
 
-	if (hitEnt:IsNPC() or hitEnt:IsPlayer()) then return end
+	if ((hitEnt:IsNPC() or hitEnt:IsNextBot()) or hitEnt:IsPlayer()) then return end
 	
 	self:OnBounce(data,phys)
 

--- a/lua/entities/obj_vj_crossbowbolt.lua
+++ b/lua/entities/obj_vj_crossbowbolt.lua
@@ -48,7 +48,7 @@ end
 function ENT:CustomOnPhysicsCollide(data, phys)
 	if IsValid(data.HitEntity) then
 		self.SoundTbl_OnCollide = {"weapons/crossbow/hitbod1.wav","weapons/crossbow/hitbod2.wav"} // weapons/crossbow/bolt_skewer1.wav
-		if data.HitEntity:IsNPC() && data.HitEntity:GetHullType() == HULL_TINY then
+		if (data.HitEntity:IsNPC() or data.HitEntity:IsNextBot()) && data.HitEntity:GetHullType() == HULL_TINY then
 			data.HitEntity:Ignite(3)
 		end
 	else

--- a/lua/entities/obj_vj_flareround.lua
+++ b/lua/entities/obj_vj_flareround.lua
@@ -114,7 +114,7 @@ end
 ---------------------------------------------------------------------------------------------------------------------------------------------
 function ENT:PhysicsCollide(data, physobj)
 	local hitEnt = data.HitEntity
-	if IsValid(hitEnt) && (hitEnt:IsNPC() or hitEnt:IsPlayer()) then
+	if IsValid(hitEnt) && ((hitEnt:IsNPC() or hitEnt:IsNextBot()) or hitEnt:IsPlayer()) then
 		//hitEnt:Ignite(1)
 		local dmg = DamageInfo()
 		dmg:SetDamage(math.random(4, 8))

--- a/lua/entities/obj_vj_projectile_base/init.lua
+++ b/lua/entities/obj_vj_projectile_base/init.lua
@@ -168,9 +168,9 @@ function ENT:DoDamageCode(data, phys)
 	
 	if self.DoesDirectDamage == true then
 		hitEnt = data.HitEntity
-		//if hitEnt:IsNPC() or hitEnt:IsPlayer() then
+		//if (hitEnt:IsNPC() or hitEnt:IsNextBot()) or hitEnt:IsPlayer() then
 		if IsValid(owner) then
-			if (VJ_IsProp(hitEnt)) or (hitEnt:IsNPC() && (hitEnt:Disposition(owner) == D_HT or hitEnt:Disposition(owner) == D_FR) && hitEnt:Health() > 0 && (hitEnt != owner) && (hitEnt:GetClass() != owner:GetClass())) or (hitEnt:IsPlayer() && GetConVar("ai_ignoreplayers"):GetInt() == 0 && hitEnt:Alive() && hitEnt:Health() > 0) then
+			if (VJ_IsProp(hitEnt)) or ((hitEnt:IsNPC() or hitEnt:IsNextBot()) && (hitEnt:Disposition(owner) == D_HT or hitEnt:Disposition(owner) == D_FR) && hitEnt:Health() > 0 && (hitEnt != owner) && (hitEnt:GetClass() != owner:GetClass())) or (hitEnt:IsPlayer() && GetConVar("ai_ignoreplayers"):GetInt() == 0 && hitEnt:Alive() && hitEnt:Health() > 0) then
 				self:CustomOnDoDamage_Direct(data, phys, hitEnt)
 				local damagecode = DamageInfo()
 				damagecode:SetDamage(self.DirectDamage)

--- a/lua/entities/obj_vj_spawner_base/init.lua
+++ b/lua/entities/obj_vj_spawner_base/init.lua
@@ -124,7 +124,7 @@ function ENT:SpawnAnEntity(spawnKey, spawnTbl, initSpawn)
 	ent:SetAngles((spawnAng or defAng) + self:GetAngles())
 	ent:Spawn()
 	ent:Activate()
-	if ent:IsNPC() && spawnWepPicked != false && string.lower(spawnWepPicked) != "none" then
+	if (ent:IsNPC() or ent:IsNextBot()) && spawnWepPicked != false && string.lower(spawnWepPicked) != "none" then
 		if string.lower(spawnWepPicked) == "default" then -- Default weapon from the spawn menu
 			local getDefWep = VJ_PICK(list.Get("NPC")[ent:GetClass()].Weapons)
 			if getDefWep then

--- a/lua/entities/sent_vj_fireplace.lua
+++ b/lua/entities/sent_vj_fireplace.lua
@@ -103,7 +103,7 @@ function ENT:OnTakeDamage(dmginfo)
 end
 ---------------------------------------------------------------------------------------------------------------------------------------------
 function ENT:Touch(entity)
-	if (IsValid(entity) && entity:GetPos():Distance(self:GetPos()) <= 38 && self.FirePlaceOn == true) && (entity:IsNPC() or entity:IsPlayer()) then
+	if (IsValid(entity) && entity:GetPos():Distance(self:GetPos()) <= 38 && self.FirePlaceOn == true) && ((entity:IsNPC() or entity:IsNextBot()) or entity:IsPlayer()) then
 		entity:Ignite(math.Rand(3,5))
 	end
 end

--- a/lua/vj_base/npc_movetype_aa.lua
+++ b/lua/vj_base/npc_movetype_aa.lua
@@ -126,7 +126,7 @@ function ENT:AA_MoveTo(dest, playAnim, moveType, extraOptions)
 			VJ_CreateTestObject(tr_check1.HitPos, self:GetAngles(), Color(0,183,255), 5)
 		end
 		-- If it hit the world, then we are too close to the ground, replace "tr" with a new position!
-		if tr_check1.Hit == true or (tr_check2.Hit == true && !tr_check2.Entity:IsNPC()) then
+		if tr_check1.Hit == true or (tr_check2.Hit == true && !(tr_check2.Entity:IsNPC() or tr_check2.Entity:IsNextBot())) then
 			if debug == true then print("Ground Hit!", tr_check1.HitPos:Distance(startPos)) end
 			//groundLimited = true
 			endPos.z = (tr_check1.Hit and myPos.z or endPos.z) + self.AA_GroundLimit

--- a/lua/weapons/gmod_tool/stools/vjstool_healthmodifier.lua
+++ b/lua/weapons/gmod_tool/stools/vjstool_healthmodifier.lua
@@ -73,14 +73,14 @@ function TOOL:LeftClick(tr)
 		local Ply = self:GetOwner()
 		local trent = tr.Entity
 		local canheal = true
-		if (trent:Health() != 0 or (trent:IsNPC() or trent:IsPlayer())) then
+		if (trent:Health() != 0 or ((trent:IsNPC() or trent:IsNextBot()) or trent:IsPlayer())) then
 			if trent:IsPlayer() && !Ply:IsAdmin() then
 				canheal = false
 			end
 			if canheal == true then
 				trent:SetHealth(self:GetClientNumber("health"))
 				Ply:ChatPrint("Set "..trent:GetClass().."'s health to "..self:GetClientNumber("health"))
-				if trent:IsNPC() then
+				if (trent:IsNPC() or trent:IsNextBot()) then
 					if self:GetClientNumber("godmode") == 1 then trent.GodMode = true else trent.GodMode = false end
 					if trent.IsVJBaseSNPC == true && self:GetClientNumber("healthregen") == 1 then
 						trent.HasHealthRegeneration = true
@@ -100,7 +100,7 @@ function TOOL:RightClick(tr)
 		local Ply = self:GetOwner()
 		local trent = tr.Entity
 		local canheal = true
-		if (trent:Health() != 0 or (trent:IsNPC() or trent:IsPlayer())) then
+		if (trent:Health() != 0 or ((trent:IsNPC() or trent:IsNextBot()) or trent:IsPlayer())) then
 			if trent:IsPlayer() && !Ply:IsAdmin() then
 				canheal = false
 			end
@@ -108,7 +108,7 @@ function TOOL:RightClick(tr)
 				trent:SetHealth(self:GetClientNumber("health"))
 				trent:SetMaxHealth(self:GetClientNumber("health"))
 				Ply:ChatPrint("Set "..trent:GetClass().."'s health and max health to "..self:GetClientNumber("health"))
-				if trent:IsNPC() then
+				if (trent:IsNPC() or trent:IsNextBot()) then
 					if self:GetClientNumber("godmode") == 1 then trent.GodMode = true else trent.GodMode = false end
 					if trent.IsVJBaseSNPC == true && self:GetClientNumber("healthregen") == 1 then
 						trent.HasHealthRegeneration = true
@@ -128,7 +128,7 @@ function TOOL:Reload(tr)
 		local Ply = self:GetOwner()
 		local trent = tr.Entity
 		local canheal = true
-		if (trent:Health() != 0 or (trent:IsNPC() or trent:IsPlayer())) then
+		if (trent:Health() != 0 or ((trent:IsNPC() or trent:IsNextBot()) or trent:IsPlayer())) then
 			if trent:IsPlayer() && !Ply:IsAdmin() then
 				canheal = false
 			end


### PR DESCRIPTION
In order to make VJ Base NPCs attack NextBots, I have done a very rudimentary search-and-replace job in the codebase. Effectively wherever there was an `ent:IsNPC()` check, I have made it into a `(ent:IsNPC() or ent:IsNextBot())` check. 

This seems to have worked on a very simple level, but the amount of replacements probably far exceeds what is necessary to achieve this functionality. I have removed changes in files where I'm reasonably sure there would be no benefit to the replacement, but there are still a lot of files changed.

Please let me know if there are other changes in this PR where the replacements can safely be removed.