### PR TITLE
Default Secondary Fires + Shotgun Reload Fix + Disposition Alternative

### DIFF
--- a/lua/autorun/vj_globals.lua
+++ b/lua/autorun/vj_globals.lua
@@ -525,6 +525,29 @@ function NPC_MetaTable:VJ_Controller_InitialMessage(ply)
 	end
 end
 ---------------------------------------------------------------------------------------------------------------------------------------------
+local AddEntityRelationship = NPC_MetaTable.AddEntityRelationship
+function NPC_MetaTable:AddEntityRelationship(...)
+	local args = {...}
+	local ent = args[1]
+	local disp = args[2]
+
+	self.StoredDispositions = self.StoredDispositions or {}
+	self.StoredDispositions[ent] = disp
+	return AddEntityRelationship(self,...)
+end
+---------------------------------------------------------------------------------------------------------------------------------------------
+local Disposition = NPC_MetaTable.Disposition
+function NPC_MetaTable:Disposition(...)
+	local args = {...}
+	local ent = args[1]
+
+	self.StoredDispositions = self.StoredDispositions or {}
+	if IsValid(ent) && self:GetModel() == ent:GetModel() then
+		return self.StoredDispositions[ent] or D_ER
+	end
+	return Disposition(self,...)
+end
+---------------------------------------------------------------------------------------------------------------------------------------------
 -- override = Used internally by the base, overrides the result and returns Val instead (Useful for variables that allow "false" to let the base decide the time)
 function NPC_MetaTable:DecideAnimationLength(anim, override, decrease)
 	if isbool(anim) then return 0 end

--- a/lua/weapons/weapon_vj_ar2/shared.lua
+++ b/lua/weapons/weapon_vj_ar2/shared.lua
@@ -35,10 +35,13 @@ SWEP.Primary.TracerType			= "AR2Tracer" -- Tracer type (Examples: AR2, laster, 9
 SWEP.Primary.Automatic			= true -- Is it automatic?
 SWEP.Primary.Ammo				= "AR2" -- Ammo type
 SWEP.Primary.Sound				= {"vj_weapons/hl2_ar2/ar2_single1.wav","vj_weapons/hl2_ar2/ar2_single2.wav","vj_weapons/hl2_ar2/ar2_single3.wav"}
-SWEP.Primary.DistantSound		= {"Weapon_AR2.NPC_Single"}
+SWEP.Primary.DistantSound		= {"^weapons/ar1/ar1_dist1.wav","^weapons/ar1/ar1_dist2.wav"}
 SWEP.PrimaryEffects_MuzzleParticles = {"vj_rifle_full_blue"}
 SWEP.PrimaryEffects_SpawnShells = false
 SWEP.PrimaryEffects_DynamicLightColor = Color(0, 31, 225)
+
+SWEP.DryFireSound = {"weapons/ar2/ar2_empty.wav"}
+SWEP.Secondary.Ammo = "AR2AltFire"
 	-- Reload Settings ---------------------------------------------------------------------------------------------------------------------------------------------
 SWEP.HasReloadSound				= false -- Does it have a reload sound? Remember even if this is set to false, the animation sound will still play!
 SWEP.ReloadSound				= "weapons/ar2/ar2_reload.wav"
@@ -68,4 +71,64 @@ function SWEP:NPC_SecondaryFire()
 		phys:Wake()
 		phys:SetVelocity(owner:CalculateProjectile("Line", pos, owner.LastEnemyVisiblePos, 2000))
 	end
+
+	VJ_CreateSound(self, "weapons/irifle/irifle_fire2.wav", 90)
+end
+---------------------------------------------------------------------------------------------------------------------------------------------
+function SWEP:CustomOnPrimaryAttack_BeforeShoot()
+	if self:GetNextSecondaryFire() > CurTime() then -- In the middle of secondary fire
+		return true
+	end
+	return false
+end
+---------------------------------------------------------------------------------------------------------------------------------------------
+function SWEP:CanSecondaryAttack()
+	return self:Clip2() > 0 && self:GetNextSecondaryFire() < CurTime()
+end
+---------------------------------------------------------------------------------------------------------------------------------------------
+function SWEP:SecondaryAttack()
+	if (!self:CanSecondaryAttack()) then return end
+
+	if self.Reloading == true then return end
+
+	local owner = self:GetOwner()
+	local vm = owner:GetViewModel()
+	local fidgetTime = VJ_GetSequenceDuration(vm, ACT_VM_FIDGET)
+	local fireTime = VJ_GetSequenceDuration(vm, ACT_VM_SECONDARYATTACK)
+	self:SetNextSecondaryFire(CurTime() + (fidgetTime + fireTime))
+	self.Reloading = true -- Compatibiliy as VJ Base has no custom reload check
+
+	self:SendWeaponAnim(ACT_VM_FIDGET)
+	VJ_CreateSound(self, "weapons/cguard/charging.wav", 85)
+	timer.Simple(fidgetTime, function()
+		if IsValid(self) && IsValid(owner) && owner:GetActiveWeapon() == self then
+			self:SendWeaponAnim(ACT_VM_SECONDARYATTACK)
+			VJ_CreateSound(self, "weapons/irifle/irifle_fire2.wav", 90)
+
+			local pos = owner:GetShootPos()
+			local proj = ents.Create(self.NPC_SecondaryFireEnt)
+			proj:SetPos(pos)
+			proj:SetAngles(owner:GetAimVector():Angle())
+			proj:SetOwner(owner)
+			proj:Spawn()
+			proj:Activate()
+			local phys = proj:GetPhysicsObject()
+			if IsValid(phys) then
+				phys:Wake()
+				phys:SetVelocity(owner:GetAimVector() * 2000)
+			end
+
+			owner:SetAnimation(PLAYER_ATTACK1)
+			owner:ViewPunch(Angle(-self.Primary.Recoil *3, 0, 0))
+			self:TakeSecondaryAmmo(1)
+		end
+	end)
+
+	timer.Simple(fidgetTime + fireTime, function()
+		if IsValid(self) then
+			self.Reloading = false -- Compatibiliy as VJ Base has no custom reload check
+			self:SetClip2(self:Ammo2())
+			self:DoIdleAnimation()
+		end
+	end)
 end

--- a/lua/weapons/weapon_vj_glock17/shared.lua
+++ b/lua/weapons/weapon_vj_glock17/shared.lua
@@ -39,6 +39,7 @@ SWEP.Primary.DistantSound		= {"vj_weapons/glock_17/glock17_single_dist.wav"}
 SWEP.PrimaryEffects_MuzzleAttachment = 1
 SWEP.PrimaryEffects_ShellAttachment = "ejectbrass"
 SWEP.PrimaryEffects_ShellType = "VJ_Weapon_PistolShell1"
+SWEP.Secondary.Automatic		= true -- Is it automatic?
 	-- Deployment Settings ---------------------------------------------------------------------------------------------------------------------------------------------
 SWEP.DelayOnDeploy 				= 0.4 -- Time until it can shoot again after deploying the weapon
 SWEP.AnimTbl_Deploy				= {ACT_VM_IDLE_TO_LOWERED}
@@ -52,3 +53,12 @@ SWEP.HasIdleAnimation			= true -- Does it have a idle animation?
 SWEP.AnimTbl_Idle				= {ACT_VM_IDLE}
 SWEP.NextIdle_Deploy			= 0.5 -- How much time until it plays the idle animation after the weapon gets deployed
 SWEP.NextIdle_PrimaryAttack		= 0.1 -- How much time until it plays the idle animation after attacking(Primary)
+---------------------------------------------------------------------------------------------------------------------------------------------
+function SWEP:SecondaryAttack()
+	self.Primary.Delay = 0.175
+	self.Primary.Cone = 20
+	self:SetNextSecondaryFire(CurTime() + self.Primary.Delay)
+	self:PrimaryAttack()
+	self.Primary.Delay = 0.25
+	self.Primary.Cone = 5
+end


### PR DESCRIPTION
- Added secondary fire code (for the player) on the AR2, Glock 17, SMG1, and Spas-12
- Optimized AR2 Ball
- Removed some code from AR2 Ball + Fixed some checks
- Added an alternative check into the Disposition function to fix 'same-model NPCs' from experiencing bizarre issues. This alternative will obviously need triple checked by you, but from my personal tests I did not see any conflictions as this change is *very* minimal