### PR TITLE
More Useful Dev Stuff

### DIFF
--- a/lua/autorun/vj_globals.lua
+++ b/lua/autorun/vj_globals.lua
@@ -255,6 +255,9 @@ function VJ_CreateSound(ent, sd, sdLevel, sdPitch, customFunc)
 		if #sd < 1 then return end -- If the table is empty then end it
 		sd = sd[math_random(1, #sd)]
 	end
+	if ent.BeforePlayCreateSound then
+		sd = ent:BeforePlayCreateSound(sd) -- Will allow people to alter sounds before they are played, since altering sounds through EntityEmitSound does not follow the logic stated on the wiki; instead of altering the sound it creates an entirely new one so stored CSoundPatch entities in VJ Base won't be altered and break
+	end
 	local sdID = CreateSound(ent, sd)
 	sdID:SetSoundLevel(sdLevel or 75)
 	if (customFunc) then customFunc(sdID) end

--- a/lua/entities/obj_vj_npccontroller/init.lua
+++ b/lua/entities/obj_vj_npccontroller/init.lua
@@ -377,47 +377,7 @@ function ENT:Think()
 		end
 		
 		-- Movement
-		if npc.MovementType != VJ_MOVETYPE_STATIONARY && npc.PlayingAttackAnimation == false && curTime > npc.NextChaseTime && npc.IsVJBaseSNPC_Tank != true then
-			local gerta_for = ply:KeyDown(IN_FORWARD)
-			local gerta_bac = ply:KeyDown(IN_BACK)
-			local gerta_lef = ply:KeyDown(IN_MOVELEFT)
-			local gerta_rig = ply:KeyDown(IN_MOVERIGHT)
-			local gerta_arak = ply:KeyDown(IN_SPEED)
-			local aimVector = ply:GetAimVector()
-			
-			if gerta_for then
-				if npc.MovementType == VJ_MOVETYPE_AERIAL or self.MovementType == VJ_MOVETYPE_AQUATIC then
-					npc:AA_MoveTo(self.VJCE_Bullseye, true, gerta_arak and "Alert" or "Calm", {IgnoreGround=true})
-				else
-					if gerta_lef then
-						self:StartMovement(aimVector, Angle(0,45,0))
-					elseif gerta_rig then
-						self:StartMovement(aimVector, Angle(0,-45,0))
-					else
-						self:StartMovement(aimVector, Angle(0,0,0))
-					end
-				end
-			elseif gerta_bac then
-				if gerta_lef then
-					self:StartMovement(aimVector*-1, Angle(0,-45,0))
-				elseif gerta_rig then
-					self:StartMovement(aimVector*-1, Angle(0,45,0))
-				else
-					self:StartMovement(aimVector*-1, Angle(0,0,0))
-				end
-			elseif gerta_lef then
-				self:StartMovement(aimVector, Angle(0,90,0))
-			elseif gerta_rig then
-				self:StartMovement(aimVector, Angle(0,-90,0))
-			else
-				npc:StopMoving()
-				if npc.MovementType == VJ_MOVETYPE_AERIAL or npc.MovementType == VJ_MOVETYPE_AQUATIC then npc:AA_StopMoving() end
-			end
-			/*if (ply:KeyDown(IN_USE)) then
-				npc:StopMoving()
-				self:StopControlling()
-			end*/
-		end
+		npc:HandleControllerMovement(self, ply, pos_beye)
 	end
 	self:NextThink(curTime + (0.069696968793869 + FrameTime()))
 end

--- a/lua/entities/obj_vj_projectile_base/init.lua
+++ b/lua/entities/obj_vj_projectile_base/init.lua
@@ -168,7 +168,7 @@ function ENT:DoDamageCode(data, phys)
 		hitEnt = data.HitEntity
 		//if hitEnt:IsNPC() or hitEnt:IsPlayer() then
 		if IsValid(owner) then
-			if (VJ_IsProp(hitEnt)) or (hitEnt:IsNPC() && (hitEnt:Disposition(owner) == D_HT or hitEnt:Disposition(owner) == D_FR) && hitEnt:Health() > 0 && (hitEnt != owner) && (hitEnt:GetClass() != owner:GetClass())) or (hitEnt:IsPlayer() && GetConVar("ai_ignoreplayers"):GetInt() == 0 && hitEnt:Alive() && hitEnt:Health() > 0) then
+			if (VJ_IsProp(hitEnt)) or (hitEnt:IsFlagSet(FL_NPC) && (hitEnt:Disposition(owner) == D_HT or hitEnt:Disposition(owner) == D_FR) && hitEnt:Health() > 0 && (hitEnt != owner) && (hitEnt:GetClass() != owner:GetClass())) or (hitEnt:IsPlayer() && GetConVar("ai_ignoreplayers"):GetInt() == 0 && hitEnt:Alive() && hitEnt:Health() > 0) then
 				self:CustomOnDoDamage_Direct(data, phys, hitEnt)
 				local damagecode = DamageInfo()
 				damagecode:SetDamage(self.DirectDamage)

--- a/lua/entities/obj_vj_projectile_base/init.lua
+++ b/lua/entities/obj_vj_projectile_base/init.lua
@@ -168,7 +168,7 @@ function ENT:DoDamageCode(data, phys)
 		hitEnt = data.HitEntity
 		//if hitEnt:IsNPC() or hitEnt:IsPlayer() then
 		if IsValid(owner) then
-			if (VJ_IsProp(hitEnt)) or (hitEnt:IsFlagSet(FL_NPC) && (hitEnt:Disposition(owner) == D_HT or hitEnt:Disposition(owner) == D_FR) && hitEnt:Health() > 0 && (hitEnt != owner) && (hitEnt:GetClass() != owner:GetClass())) or (hitEnt:IsPlayer() && GetConVar("ai_ignoreplayers"):GetInt() == 0 && hitEnt:Alive() && hitEnt:Health() > 0) then
+			if (VJ_IsProp(hitEnt)) or (hitEnt:IsNPC() && (hitEnt:Disposition(owner) == D_HT or hitEnt:Disposition(owner) == D_FR) && hitEnt:Health() > 0 && (hitEnt != owner) && (hitEnt:GetClass() != owner:GetClass())) or (hitEnt:IsPlayer() && GetConVar("ai_ignoreplayers"):GetInt() == 0 && hitEnt:Alive() && hitEnt:Health() > 0) then
 				self:CustomOnDoDamage_Direct(data, phys, hitEnt)
 				local damagecode = DamageInfo()
 				damagecode:SetDamage(self.DirectDamage)

--- a/lua/vj_base/npc_general.lua
+++ b/lua/vj_base/npc_general.lua
@@ -1156,6 +1156,52 @@ function ENT:DoConstantlyFaceEnemy()
 	return false
 end
 ---------------------------------------------------------------------------------------------------------------------------------------------
+function ENT:HandleControllerMovement(cont, ply, bullseyePos)
+	if self.MovementType != VJ_MOVETYPE_STATIONARY && self.PlayingAttackAnimation == false && CurTime() > self.NextChaseTime && self.IsVJBaseSNPC_Tank != true then
+		local gerta_for = ply:KeyDown(IN_FORWARD)
+		local gerta_bac = ply:KeyDown(IN_BACK)
+		local gerta_lef = ply:KeyDown(IN_MOVELEFT)
+		local gerta_rig = ply:KeyDown(IN_MOVERIGHT)
+		local gerta_arak = ply:KeyDown(IN_SPEED)
+		local aimVector = ply:GetAimVector()
+		
+		if gerta_for then
+			if self.MovementType == VJ_MOVETYPE_AERIAL or self.MovementType == VJ_MOVETYPE_AQUATIC then
+				self:AA_MoveTo(cont.VJCE_Bullseye, true, gerta_arak and "Alert" or "Calm", {IgnoreGround=true})
+			else
+				if gerta_lef then
+					cont:StartMovement(aimVector, Angle(0,45,0))
+				elseif gerta_rig then
+					cont:StartMovement(aimVector, Angle(0,-45,0))
+				else
+					cont:StartMovement(aimVector, Angle(0,0,0))
+				end
+			end
+		elseif gerta_bac then
+			if gerta_lef then
+				cont:StartMovement(aimVector*-1, Angle(0,-45,0))
+			elseif gerta_rig then
+				cont:StartMovement(aimVector*-1, Angle(0,45,0))
+			else
+				cont:StartMovement(aimVector*-1, Angle(0,0,0))
+			end
+		elseif gerta_lef then
+			cont:StartMovement(aimVector, Angle(0,90,0))
+		elseif gerta_rig then
+			cont:StartMovement(aimVector, Angle(0,-90,0))
+		else
+			self:StopMoving()
+			if self.MovementType == VJ_MOVETYPE_AERIAL or self.MovementType == VJ_MOVETYPE_AQUATIC then
+				self:AA_StopMoving()
+			end
+		end
+		/*if (ply:KeyDown(IN_USE)) then
+			self:StopMoving()
+			cont:StopControlling()
+		end*/
+	end
+end
+---------------------------------------------------------------------------------------------------------------------------------------------
 function ENT:VJ_PlaySequence(seq, playbackRate, reset, resetTime, interruptible)
 	if !seq then return end
 	if interruptible == true then


### PR DESCRIPTION
- Added optional function call; Entity:BeforePlayCreateSound(sd)

_The above function is used to modify sounds created through VJ Base functions, because if you try to modify them through sound hooks it doesn't apply to VJ Base variables/values, therefore breaking a lot of stuff in the NPC's sound code. For example, with this function I was able to create a dynamic language system where NPC's language changed with the click of a convar while spawned in_

- Relocated the controller's movement code to npc_general.lua, allowing developers to create custom movement code. This does not change anything by default, its a simple relocation to allow customization

_For example, I was able to create NPCs that only utilized 4-Way movement, 6-Way movement, or the default 8-Way movement_