### PR TITLE
VJ Base causing bugs with duplicator code

### DIFF
--- a/lua/autorun/vj_menu_spawn.lua
+++ b/lua/autorun/vj_menu_spawn.lua
@@ -324,7 +324,7 @@ local function VJSPAWN_NPCINTERNAL(Player, Position, Normal, Class, Equipment, S
 		end
 	return end*/
 
-		local isValidPly = IsValid(Player)
+	local isValidPly = IsValid(Player)
 
 	if ( NPCData.AdminOnly && isValidPly && !Player:IsAdmin() ) then return end
 

--- a/lua/autorun/vj_menu_spawn.lua
+++ b/lua/autorun/vj_menu_spawn.lua
@@ -323,7 +323,10 @@ local function VJSPAWN_NPCINTERNAL(Player, Position, Normal, Class, Equipment, S
 			Player:SendLua("Derma_Message(\"Hey, stop trying to spawn it, your not allowed to!\")")
 		end
 	return end*/
-	if (NPCData.AdminOnly && !Player:IsAdmin()) then return end
+
+		local isValidPly = IsValid(Player)
+
+	if ( NPCData.AdminOnly && isValidPly && !Player:IsAdmin() ) then return end
 
 	local bDropToFloor = false
 	if ( NPCData.OnCeiling && Vector( 0, 0, -1 ):Dot( Normal ) < 0.95 ) then -- This NPC has to be spawned on a ceiling (Barnacle)
@@ -347,7 +350,7 @@ local function VJSPAWN_NPCINTERNAL(Player, Position, Normal, Class, Equipment, S
 	
 	-- Rotate to face player (expected behavior)
 	local Angles = Angle( 0, 0, 0 )
-		if ( IsValid( Player ) ) then
+		if ( isValidPly ) then
 			Angles = Player:GetAngles()
 		end
 		Angles.pitch = 0


### PR DESCRIPTION
The code looks like it used to support no players, but someone added an IsAdmin check. I have put this behind a player is valid check now.

Players aren't valid some times as other addons will use duplicator to cleanly save entities