### PR TITLE
Controller Update Options

### DIFF
--- a/lua/entities/obj_vj_npccontroller/shared.lua
+++ b/lua/entities/obj_vj_npccontroller/shared.lua
@@ -60,19 +60,20 @@ if CLIENT then
 			pos = tr.HitPos + tr.HitNormal*2
 		end
 
+		local lerpSpeed = ply:GetInfoNum("vj_npc_cont_cam_speed", 6)
 		if npc.Controller_CalcView then -- Allows custom calcview overrides
 			local data = npc:Controller_CalcView(ply, pos, ang, fov, origin, angles, cameraMode)
 			if data then
 				pos = data.origin or pos
 				ang = data.angles or ang
 				fov = data.fov or fov
+				lerpSpeed = (data.speed == false && 0 or data.speed) or lerpSpeed
 			end
 		end
-		
+
 		-- Lerp the position and the angle
-		local lerpSpeed = ply:GetInfoNum("vj_npc_cont_cam_speed", 6)
-		viewLerpVec = (cameraMode == 2 and pos) or LerpVector(FrameTime()*lerpSpeed, viewLerpVec, pos)
-        viewLerpAng = LerpAngle(FrameTime()*lerpSpeed, viewLerpAng, ang)
+		viewLerpVec = (cameraMode == 2 and pos) or (lerpSpeed != 0 && LerpVector(FrameTime()*lerpSpeed, viewLerpVec, pos) or pos)
+        viewLerpAng = (lerpSpeed != 0 && LerpAngle(FrameTime()*lerpSpeed, viewLerpAng, ang) or ang)
 		
 		-- Send the player's hit position to the controller entity
 		local tr = util.TraceLine({start = viewLerpVec, endpos = viewLerpVec + viewLerpAng:Forward()*32768, filter = {ply, camera, npc}})


### PR DESCRIPTION
- Added extra return parameter for changing the controller camera speed. Useful for NPCs that move so fast the camera can't keep up regardless of the number

Example code of it in use:
![image](https://user-images.githubusercontent.com/7193583/224917586-d2ef0b34-b161-47c7-aeb2-40ceaa373590.png)

By setting speed to 'false', I disable the lerping entirely. Or I can set it to a number to override the convar