### PR TITLE
Controller Improvements

### DIFF
--- a/lua/entities/npc_vj_creature_base/shared.lua
+++ b/lua/entities/npc_vj_creature_base/shared.lua
@@ -38,7 +38,7 @@ if CLIENT then
 	//function ENT:CalcAbsolutePosition(pos, ang) end
 	-- Custom functions ---------------------------------------------------------------------------------------------------------------------------------------------
 	function ENT:CustomOnDraw() end
-	-- function ENT:CustomOnCalcView(ply, origin, angles, fov, camera, cameraMode) return false end -- Return true, as well as a table of data to override the default camera calculations
+	function ENT:CustomOnCalcView(ply, origin, angles, fov, camera, cameraMode) return false end -- Return true, as well as a table of data to override the default camera calculations
 	/*
 		Example:
 		function ENT:CustomOnCalcView(ply, origin, angles, fov, camera, cameraMode)

--- a/lua/entities/npc_vj_creature_base/shared.lua
+++ b/lua/entities/npc_vj_creature_base/shared.lua
@@ -38,6 +38,17 @@ if CLIENT then
 	//function ENT:CalcAbsolutePosition(pos, ang) end
 	-- Custom functions ---------------------------------------------------------------------------------------------------------------------------------------------
 	function ENT:CustomOnDraw() end
-	-- UNCOMMENT TO USE | Override the NPC Controller's view by returning a table that can take the following values: {pos, ang, fov, speed}
-	-- function ENT:Controller_CalcView(ply, pos, ang, fov, origin, angles, cameraMode) end
+	-- function ENT:CustomOnCalcView(ply, origin, angles, fov, camera, cameraMode) return false end -- Return true, as well as a table of data to override the default camera calculations
+	/*
+		Example:
+		function ENT:CustomOnCalcView(ply, origin, angles, fov, camera, cameraMode)
+			if cameraMode == 1 then -- We're in third-person, use our cool new view!
+				return true, {origin = origin - (angles:Forward() * 300)}
+			end
+			return false
+		end
+
+		Return table values are origin, angles, fov, speed
+		All table values are optional, but be careful as the default values that will be used instead are not good!
+	*/
 end

--- a/lua/entities/npc_vj_human_base/shared.lua
+++ b/lua/entities/npc_vj_human_base/shared.lua
@@ -38,6 +38,17 @@ if CLIENT then
 	//function ENT:CalcAbsolutePosition(pos, ang) end
 	-- Custom functions ---------------------------------------------------------------------------------------------------------------------------------------------
 	function ENT:CustomOnDraw() end
-	-- UNCOMMENT TO USE | Override the NPC Controller's view by returning a table that can take the following values: {pos, ang, fov, speed}
-	-- function ENT:Controller_CalcView(ply, pos, ang, fov, origin, angles, cameraMode) end
+	function ENT:CustomOnCalcView(ply, origin, angles, fov, camera, cameraMode) return false end -- Return true, as well as a table of data to override the default camera calculations
+	/*
+		Example:
+		function ENT:CustomOnCalcView(ply, origin, angles, fov, camera, cameraMode)
+			if cameraMode == 1 then -- We're in third-person, use our cool new view!
+				return true, {origin = origin - (angles:Forward() * 300)}
+			end
+			return false
+		end
+
+		Return table values are origin, angles, fov, speed
+		All table values are optional, but be careful as the default values that will be used instead are not good!
+	*/
 end


### PR DESCRIPTION
- Removed ENT:Controller_CalcView()
- Added ENT:CustomOnCalcView(ply, origin, angles, fov, camera, cameraMode)
- Minor uninteresting optimization
- Added Controller.VJC_RefreshBullseyePosition
- Added Controller.VJC_NPC_AllowTurning
- Fixed controller shadow drawing at map origin
- Fixed player's God mode being stripped when exiting a NPC if they had it prior
- Fixed a spacing issue
- Moved a check in the Controller:Think() function to make the controller obey the same logic as NPCs (no shooting while flinching/jumping)

The calc view code was adjusted so that you can just completely override the normal code; therefore giving the developer full control over the view without the other code running in the background. I also added a variable for disabling the bullseye from refreshing server-side; this will allow developers to either pause or manually set the bullseye. This is useful for unique targetting codes and what not as the bullseye position is not a great solution for some things on the NPC's side. For example, in one of my mods the NPC spawns an object at the enemy's position, the problem here is the bullseye is elevated near the enemy's thighs so the object noticeably spawns well above where it should while controlling.

Changes were tested with Half-Life Resurgence NPCs.