### PR TITLE
Fixes

### DIFF
--- a/lua/entities/npc_vj_human_base/init.lua
+++ b/lua/entities/npc_vj_human_base/init.lua
@@ -3071,14 +3071,8 @@ function ENT:ThrowGrenadeCode(customEnt, noOwner)
 				getSpawnPos = self:CustomOnGrenadeAttack_SpawnPosition()
 				getSpawnAngle = getSpawnPos:Angle()
 			else
-				local att = self:LookupAttachment(self.GrenadeAttackAttachment)
-				if att > 0 then
-					getSpawnPos = self:GetAttachment(att).Pos
-					getSpawnAngle = self:GetAttachment(att).Ang
-				else
-					getSpawnPos = self:GetShootPos()
-					getSpawnAngle = self:GetAngles()
-				end
+				getSpawnPos = self:GetAttachment(self:LookupAttachment(self.GrenadeAttackAttachment)).Pos
+				getSpawnAngle = self:GetAttachment(self:LookupAttachment(self.GrenadeAttackAttachment)).Ang
 			end
 	
 			local greTargetPos = self:GetPos() + self:GetForward()*200

--- a/lua/entities/npc_vj_human_base/init.lua
+++ b/lua/entities/npc_vj_human_base/init.lua
@@ -3071,8 +3071,14 @@ function ENT:ThrowGrenadeCode(customEnt, noOwner)
 				getSpawnPos = self:CustomOnGrenadeAttack_SpawnPosition()
 				getSpawnAngle = getSpawnPos:Angle()
 			else
-				getSpawnPos = self:GetAttachment(self:LookupAttachment(self.GrenadeAttackAttachment)).Pos
-				getSpawnAngle = self:GetAttachment(self:LookupAttachment(self.GrenadeAttackAttachment)).Ang
+				local att = self:LookupAttachment(self.GrenadeAttackAttachment)
+				if att > 0 then
+					getSpawnPos = self:GetAttachment(att).Pos
+					getSpawnAngle = self:GetAttachment(att).Ang
+				else
+					getSpawnPos = self:GetShootPos()
+					getSpawnAngle = self:GetAngles()
+				end
 			end
 	
 			local greTargetPos = self:GetPos() + self:GetForward()*200

--- a/lua/entities/npc_vj_test_humanply/init.lua
+++ b/lua/entities/npc_vj_test_humanply/init.lua
@@ -67,6 +67,7 @@ end
 ---------------------------------------------------------------------------------------------------------------------------------------------
 function ENT:CustomOnInitialize()
 	VJ.EmitSound(self, "player/pl_drown1.wav") -- Player connect sound
+	self:SetSurroundingBoundsType(0)
 end
 ---------------------------------------------------------------------------------------------------------------------------------------------
 function ENT:GetSightDirection()

--- a/lua/entities/obj_vj_projectile_base/init.lua
+++ b/lua/entities/obj_vj_projectile_base/init.lua
@@ -167,7 +167,7 @@ function ENT:DoDamageCode(data, phys)
 		hitEnt = data.HitEntity
 		//if hitEnt:IsNPC() or hitEnt:IsPlayer() then
 		if IsValid(owner) then
-			if (VJ.IsProp(hitEnt)) or (hitEnt:IsNPC() && (hitEnt:Disposition(owner) == D_HT or hitEnt:Disposition(owner) == D_FR) && hitEnt:Health() > 0 && (hitEnt != owner) && (hitEnt:GetClass() != owner:GetClass())) or (hitEnt:IsPlayer() && !VJ_CVAR_IGNOREPLAYERS && hitEnt:Alive() && hitEnt:Health() > 0) then
+			if (VJ.IsProp(hitEnt)) or (hitEnt:IsNPC() && (hitEnt:Disposition(owner) == D_HT or hitEnt:Disposition(owner) == D_FR) && hitEnt:Health() > 0 && (hitEnt != owner) && (hitEnt:GetClass() != owner:GetClass())) or (hitEnt:IsPlayer() && !VJ_CVAR_IGNOREPLAYERS && hitEnt:Alive() && hitEnt:Health() > 0) or (!hitEnt:IsNPC() && !hitEnt:IsPlayer() && (hitEnt:Health() != nil && hitEnt:Health() > 0)) then
 				self:CustomOnDoDamage_Direct(data, phys, hitEnt)
 				local dmgInfo = DamageInfo()
 				dmgInfo:SetDamage(self.DirectDamage)


### PR DESCRIPTION
This is a small pull requests that fixes long-time issues, as well as temporarily fixes stuff.

The first change to note is the player test NPC no longer uses SetSurroundingBoundsType(), as this function breaks collision on all NPCs at the expense of proper trace hitting. Its not needed on this NPC as they are a simple biped.

The second change is a temporary fix for the human base, where models without proper attachments in the grenade attack code will no longer error, rather the grenade spawns at a default position instead.

The third change fixes VJ Base projectiles only being able to damage props, NPCs and players. While there could be a better way to achieve this fix, from testing a simple Health verification seems to work on all the entities I tried. I think this might be all that is needed as we aren't doing anything special after this other than applying the damage.